### PR TITLE
engines: customer-socket features; count, dynamic timeout, latency calc

### DIFF
--- a/core/lib/runner.js
+++ b/core/lib/runner.js
@@ -378,6 +378,10 @@ function runScenario(script, intermediate, runState, ee) {
       // Bubble up custom events from a scenario's processor function(s)
       ee.emit('custom', payload);
     })
+    runState.scenarioEvents.on('reset_stats', function() {
+      // For websocket work, we may not want HTTP latencies to clutter
+      intermediate.reset();
+    })
     runState.compiledScenarios = _.map(
         script.scenarios,
         function(scenarioSpec) {


### PR DESCRIPTION
To truly test the capacity of the websocket server, we must be able to set up a
bunch of listeners and test multiple messages.  Allow timeouts to be turned off
so we can have indefinite testing.  Allow capturing payload fields, especially being
able to select a date field from the reply and use it to calculate true over-the-wire
latency.  Also, set up a `count` of messages to receive before exiting.  This can
be used for broadcast event testing with an external publisher.